### PR TITLE
Update FindGMP.cmake: also look for libgmp.so in $GMP_DIR

### DIFF
--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -1,5 +1,5 @@
 message( STATUS "Looking for GMP")
-find_library(LIBGMP gmp PATHS /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64)
+find_library(LIBGMP gmp PATHS /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64 ${GMP_DIR}/lib ${GMP_DIR}/lib64)
 if( LIBGMP STREQUAL LIBGMP-NOTFOUND)
    set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE "GMP library was not found")
    set(${CMAKE_FIND_PACKAGE}-FOUND FALSE)


### PR DESCRIPTION
${GMP_DIR} was only used to look for the include file, but not for the library file.
With this change, users can provide their own installation of GMP to CHROMA.